### PR TITLE
GET /api/articles (filter by topic and sorting improvements)

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -415,9 +415,9 @@ describe("GET /api/users ", () => {
           expect(user).toHaveProperty("username");
           expect(user).toHaveProperty("name");
           expect(user).toHaveProperty("avatar_url");
-          expect(typeof user.username).toBe('string');
-          expect(typeof user.name).toBe('string');
-          expect(typeof user.avatar_url).toBe('string');
+          expect(typeof user.username).toBe("string");
+          expect(typeof user.name).toBe("string");
+          expect(typeof user.avatar_url).toBe("string");
         });
       });
   });
@@ -431,7 +431,7 @@ describe("GET /api/users ", () => {
   });
 });
 
-describe("GET /api/articles/sort_by=created_at&order=asc", () => {
+describe("GET /api/articles?sort_by=created_at&order=asc", () => {
   test("200: Responds with the articles by the order desc", () => {
     return request(app)
       .get("/api/articles?sort_by=created_at&order=desc")
@@ -470,6 +470,50 @@ describe("GET /api/articles/sort_by=created_at&order=asc", () => {
         expect(body.articles).toBeSortedBy("created_at", {
           descending: false,
         });
+      });
+  });
+});
+describe("GET /api/articles?topics=mitch", () => {
+  test("200: Responds with articles filtered by topic", () => {
+    return request(app)
+      .get("/api/articles?topic=mitch")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articles.length).toBe(12);
+        body.articles.forEach((article) => {
+          expect(article.topic).toBe("mitch");
+        });
+      });
+  });
+  test("200: Responds with articles filtered by topic", () => {
+    return request(app)
+      .get("/api/articles?topic=cats")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articles.length).toBe(1);
+        body.articles.forEach((article) => {
+          expect(article.topic).toBe("cats");
+        });
+      });
+  });
+  test("200: Responds with articles filtered by various queries", () => {
+    return request(app)
+      .get("/api/articles?sort_by=created_at&order=asc&topic=mitch")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articles.length).toBe(12);
+        expect(body.articles).toBeSortedBy("created_at", { descending: false });
+        body.articles.forEach((article) => {
+          expect(article.topic).toBe("mitch");
+        });
+      });
+  });
+  test("400: Responds with an error if query does not exist", () => {
+    return request(app)
+      .get("/api/articles?topic='market")
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.error).toBe("Topic not found");
       });
   });
 });

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -15,12 +15,12 @@ const getArticlesById = (req, res, next) => {
 };
 
 const getAllArticles = (req, res, next) => {
-  const { sort_by, order } = req.query;
+  const { sort_by, order, topic } = req.query;
 
 
  
 
-  return fetchArticle({sort_by, order})
+  return fetchArticle({sort_by, order, topic})
   .then(( articles ) => {
     res.status(200).send({ articles })
   })


### PR DESCRIPTION
After this merge, the endpoint should support filtering articles by topic while allowing dynamic sorting by any valid column with a default to created_at and ordering in ascending or descending order with a default to descending ensuring proper error handling for invalid queries and comprehensive testing